### PR TITLE
added transform-object-assign package required for slick carousel fun…

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
   "plugins": [
     "react-hot-loader/babel",
     "transform-object-rest-spread",
+    "transform-object-assign",
     ["transform-es2015-classes", {
       "loose": true
     }, "transform-runtime"]

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-core": "^6.17.0",
     "babel-loader": "^6.2.5",
     "babel-plugin-transform-es2015-classes": "^6.14.0",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.16.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-polyfill": "^6.16.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -151,6 +151,21 @@ module.exports = {
         include: /flexboxgrid/
       },
       {
+        test: /\.woff(\?v=\d+\.\d+\.\d+)?$/,
+        loader: "url?limit=10000&mimetype=application/font-woff"
+      }, {
+        test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/,
+        loader: "url?limit=10000&mimetype=application/font-woff"
+      }, {
+        test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/,
+        loader: "url?limit=10000&mimetype=application/octet-stream"
+      }, {
+        test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
+        loader: "file"
+      }, {
+        test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+        loader: "url?limit=10000&mimetype=image/svg+xml"
+      }, {
         test: /\.scss$/,
         use: ExtractTextPlugin.extract({
           use: [{

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,6 +913,12 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-object-assign@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz#f99d2f66f1a0b0d498e346c5359684740caa20ba"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-object-rest-spread@^6.16.0, babel-plugin-transform-object-rest-spread@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.22.0.tgz#1d419b55e68d2e4f64a5ff3373bd67d73c8e83bc"


### PR DESCRIPTION
Added `transform-object-assign`, it was required for slick-carousel functionality and started to add font loaders for font-awesome, but not finished yet.